### PR TITLE
Implement dynamic progress tracking

### DIFF
--- a/src/app/components/UltraStats.tsx
+++ b/src/app/components/UltraStats.tsx
@@ -1,15 +1,10 @@
 "use client";
 
-import { useState } from "react";
-import type { Waypoint } from "@/lib/database.types";
-import { calculateDistance } from "@/lib/calculate";
-
 interface UltraStatsProps {
-  waypoints: Waypoint[];
+  progress: number;
 }
 
-export default function UltraStats({ waypoints }: UltraStatsProps) {
-  const [totalProgress] = useState<number>(0);
+export default function UltraStats({ progress }: UltraStatsProps) {
 
   return (
     <div className="space-y-6">
@@ -21,13 +16,13 @@ export default function UltraStats({ waypoints }: UltraStatsProps) {
             <div className="flex justify-between items-center mb-2">
               <span className="text-sm font-medium">Progression totale</span>
               <span className="text-sm text-muted-foreground">
-                {totalProgress.toFixed(1)}%
+                {progress.toFixed(1)}%
               </span>
             </div>
             <div className="w-full bg-muted rounded-full h-3">
               <div
                 className="bg-primary h-3 rounded-full transition-all duration-500"
-                style={{ width: `${totalProgress}%` }}
+                style={{ width: `${progress}%` }}
               />
             </div>
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import Providers from "./providers";
+import Script from "next/script";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,9 +16,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <script
-          crossOrigin="anonymous"
+        <Script
           src="//unpkg.com/react-scan/dist/auto.global.js"
+          strategy="afterInteractive"
+          crossOrigin="anonymous"
         />
       </head>
       <body className="antialiased">


### PR DESCRIPTION
## Summary
- compute progress along track using live track position
- show progress card before live stats
- fix lint rule by replacing script tag with Next.js `Script`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6852f9a8340c8325a07aa50154bd7998