### PR TITLE
Change real-time marker to runner with stats

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -93,7 +93,6 @@ export default function HomeClient({
               <div className="h-96 w-full rounded-lg overflow-hidden border relative">
                 <UltraMap
                   waypoints={waypoints}
-                  steps={steps}
                   trackpoints={trackpoints}
                   liveTrackData={liveTrackData || undefined}
                   isConnected={isConnected}

--- a/src/app/components/UltaMap.tsx
+++ b/src/app/components/UltaMap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Trackpoint, Waypoint, Step } from "@/lib/database.types";
+import { Trackpoint, Waypoint } from "@/lib/database.types";
 import {
   MapContainer,
   Marker,
@@ -26,7 +26,6 @@ const createEmojiIcon = (emoji: string, size: [number, number] = [30, 30]) => {
 
 interface UltraMapProps {
   waypoints: Waypoint[];
-  steps: Step[];
   trackpoints: Trackpoint[];
   liveTrackData?: {
     trackPoints: TrackPoint[];
@@ -84,7 +83,6 @@ function getEtaForWaypoint({
 
 export default function UltraMap({
   waypoints,
-  steps,
   trackpoints,
   liveTrackData,
   isConnected = false,
@@ -211,8 +209,31 @@ export default function UltraMap({
             currentPosition.position.lat,
             currentPosition.position.lon,
           ]}
-          icon={createEmojiIcon("🔴")}
-        />
+          icon={createEmojiIcon("🏃‍➡️")}
+        >
+          <Popup>
+            <div className="text-sm space-y-1">
+              <div>
+                🏃 Vitesse :
+                {" "}
+                {(
+                  (currentPosition.fitnessPointData?.speedMetersPerSec ||
+                    currentPosition.speed ||
+                    0) *
+                  3.6
+                ).toFixed(1)}
+                {" km/h"}
+              </div>
+              {currentPosition.fitnessPointData?.heartRateBeatsPerMin != null && (
+                <div>
+                  ❤️ Fréquence cardiaque :
+                  {" "}
+                  {currentPosition.fitnessPointData.heartRateBeatsPerMin} bpm
+                </div>
+              )}
+            </div>
+          </Popup>
+        </Marker>
       )}
       {/* Waypoints avec des markers */}
       {waypoints.map((waypoint) => {


### PR DESCRIPTION
## Summary
- show runner icon for current location on UltraMap
- add popup with speed and heart rate
- drop unused `steps` prop from `UltraMap`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853acc46f648325b90620b1584122e9