### PR TITLE
Fix end point using ordered trackpoints

### DIFF
--- a/src/lib/dataParser.ts
+++ b/src/lib/dataParser.ts
@@ -7,7 +7,7 @@ export async function getData() {
   const [waypoints, steps, trackpoints, liveTrackConfig] = await Promise.all([
     supabase.from("waypoints").select("*"),
     supabase.from("steps").select("*"),
-    supabase.from("trackpoints").select("*"),
+    supabase.from("trackpoints").select("*").order("time", { ascending: true }),
     getLiveTrackConfig(),
   ]);
 


### PR DESCRIPTION
## Summary
- ensure fetched trackpoints are ordered by time

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68543152dd2c8325b33aa1fee6ea219b