### PR TITLE
Add real-time user location layer

### DIFF
--- a/src/app/components/UltaMap.tsx
+++ b/src/app/components/UltaMap.tsx
@@ -13,6 +13,7 @@ import L from "leaflet";
 import { TrackPoint } from "@/lib/useLiveTrack";
 import { findClosestTrackPoint } from "@/lib/calculate";
 import { format } from "date-fns";
+import UserLocationLayer from "./UserLocationLayer";
 
 // Simple emoji based icon generator
 const createEmojiIcon = (emoji: string, size: [number, number] = [30, 30]) => {
@@ -282,6 +283,9 @@ export default function UltraMap({
           </Marker>
         )}
       </Pane>
+
+      {/* Localisation de l'utilisateur */}
+      <UserLocationLayer />
     </MapContainer>
   );
 }

--- a/src/app/components/UserLocationLayer.tsx
+++ b/src/app/components/UserLocationLayer.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Marker, Popup, Pane } from "react-leaflet";
+import L from "leaflet";
+import { useCurrentLocation } from "@/lib/useCurrentLocation";
+
+const createEmojiIcon = (emoji: string, size: [number, number] = [20, 20]) => {
+  return L.divIcon({
+    html: `<div style="font-size:${size[0]}px;">${emoji}</div>`,
+    iconSize: size,
+    className: "",
+    iconAnchor: [size[0] / 2, size[1]],
+    popupAnchor: [0, -size[1]],
+  });
+};
+
+export default function UserLocationLayer() {
+  const { position } = useCurrentLocation();
+
+  if (!position) return null;
+
+  return (
+    <Pane name="userLocation" style={{ zIndex: 440 }}>
+      <Marker
+        position={[position.lat, position.lng]}
+        icon={createEmojiIcon("🧍", [20, 20])}
+      >
+        <Popup>Vous êtes ici</Popup>
+      </Marker>
+    </Pane>
+  );
+}

--- a/src/app/components/UserLocationLayer.tsx
+++ b/src/app/components/UserLocationLayer.tsx
@@ -4,13 +4,21 @@ import { Marker, Popup, Pane } from "react-leaflet";
 import L from "leaflet";
 import { useCurrentLocation } from "@/lib/useCurrentLocation";
 
-const createEmojiIcon = (emoji: string, size: [number, number] = [20, 20]) => {
+const createBlueDotIcon = (size = 12) => {
+  const style = [
+    "background:#007aff",
+    `width:${size}px`,
+    `height:${size}px`,
+    "border-radius:50%",
+    "box-shadow:0 0 0 2px white,0 0 6px 2px rgba(0,122,255,0.5)",
+  ].join(";");
+
   return L.divIcon({
-    html: `<div style="font-size:${size[0]}px;">${emoji}</div>`,
-    iconSize: size,
+    html: `<div style="${style}"></div>`,
+    iconSize: [size, size],
     className: "",
-    iconAnchor: [size[0] / 2, size[1]],
-    popupAnchor: [0, -size[1]],
+    iconAnchor: [size / 2, size / 2],
+    popupAnchor: [0, -size / 2],
   });
 };
 
@@ -23,7 +31,7 @@ export default function UserLocationLayer() {
     <Pane name="userLocation" style={{ zIndex: 440 }}>
       <Marker
         position={[position.lat, position.lng]}
-        icon={createEmojiIcon("🧍", [20, 20])}
+        icon={createBlueDotIcon()}
       >
         <Popup>Vous êtes ici</Popup>
       </Marker>

--- a/src/lib/useCurrentLocation.ts
+++ b/src/lib/useCurrentLocation.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+
+interface Position {
+  lat: number;
+  lng: number;
+}
+
+export function useCurrentLocation() {
+  const [position, setPosition] = useState<Position | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      setError("Geolocation not supported");
+      return;
+    }
+
+    const watchId = navigator.geolocation.watchPosition(
+      (pos) => {
+        setPosition({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+      },
+      (err) => {
+        setError(err.message);
+      },
+      { enableHighAccuracy: true }
+    );
+
+    return () => navigator.geolocation.clearWatch(watchId);
+  }, []);
+
+  return { position, error };
+}


### PR DESCRIPTION
## Summary
- track user's geolocation in `useCurrentLocation` hook
- show user's location on the map via new `UserLocationLayer` component
- include the new layer inside `UltraMap`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547d398b0c832588a76594fc00f767